### PR TITLE
投稿とコメントの削除機能と削除時のDBのエラー処理の実装

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -14,10 +14,16 @@ class CommentController extends Controller
             $images = $request->file('image');
             for($i = 0; $i < count($images); $i++) {
                 $image_url = Cloudinary::upload($images[$i]->getRealPath())->getSecurePath();
-                $input += ['image'.($i + 1) => $image_url];
+                $input += ['image'. ($i + 1) => $image_url];
             }
         }
         $comment->fill($input)->save();
         return redirect('/posts/'. $comment->post_id); 
+    }
+    
+    public function delete(Comment $comment) {
+        $post_id = $comment->post_id;
+        $comment->delete();
+        return redirect('/posts/'. $post_id);
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -33,4 +33,9 @@ class PostController extends Controller
     public function show(Post $post) {
         return view('posts.show')->with(['post' => $post]);
     }
+    
+    public function delete(Post $post) {
+        $post->delete();
+        return redirect('/');
+    }
 }

--- a/database/migrations/2023_09_03_075920_create_user_usertags_table.php
+++ b/database/migrations/2023_09_03_075920_create_user_usertags_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('user_usertags', function (Blueprint $table) {
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('usertag_id')->constrained();
             
             $table->unique([

--- a/database/migrations/2023_09_04_025440_create_follows_table.php
+++ b/database/migrations/2023_09_04_025440_create_follows_table.php
@@ -14,8 +14,8 @@ return new class extends Migration
     public function up()
     {
         Schema::create('follows', function (Blueprint $table) {
-            $table->foreignId('follower_id')->constrained('users')->comment('フォローしてる人のID');
-            $table->foreignId('followed_id')->constrained('users')->comment('フォローされてる人のID');
+            $table->foreignId('follower_id')->constrained('users')->cascadeOnDelete()->comment('フォローしてる人のID');
+            $table->foreignId('followed_id')->constrained('users')->cascadeOnDelete()->comment('フォローされてる人のID');
             
             //フォローの重複を防ぐ
             $table->unique([

--- a/database/migrations/2023_09_04_032745_create_posts_table.php
+++ b/database/migrations/2023_09_04_032745_create_posts_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('category_id')->constrained()->comment('カテゴリーID'); //ID「0」は「カテゴリーなし」
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained()->nullOnDelete()->comment('カテゴリーID'); //ID「0」は「カテゴリーなし」
             $table->string('content', 300)->nullable()->comment('本文');
             $table->string('image1')->nullable()->comment('添付画像1');
             $table->string('image2')->nullable()->comment('添付画像2');

--- a/database/migrations/2023_09_04_032747_create_post_posttags_table.php
+++ b/database/migrations/2023_09_04_032747_create_post_posttags_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('post_posttags', function (Blueprint $table) {
-            $table->foreignId('post_id')->constrained();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             $table->foreignId('posttag_id')->constrained();
             
             $table->unique([

--- a/database/migrations/2023_09_04_052416_create_likes_table.php
+++ b/database/migrations/2023_09_04_052416_create_likes_table.php
@@ -14,8 +14,8 @@ return new class extends Migration
     public function up()
     {
         Schema::create('likes', function (Blueprint $table) {
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('post_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             
             $table->unique([
                 'user_id',

--- a/database/migrations/2023_09_06_050843_create_mains_table.php
+++ b/database/migrations/2023_09_06_050843_create_mains_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('mains', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('category_id')->constrained();
             $table->string('title', 50)->comment('タイトル');
             $table->string('content', 500)->comment('本文'); //URLも貼れる

--- a/database/migrations/2023_09_06_051447_create_stores_table.php
+++ b/database/migrations/2023_09_06_051447_create_stores_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('stores', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('storecategory_id')->constrained();
             $table->string('title', 50)->comment('タイトル');
             $table->string('content', 500)->comment('本文'); //URLも貼れる

--- a/database/migrations/2023_09_07_015605_create_comments_table.php
+++ b/database/migrations/2023_09_07_015605_create_comments_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('post_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('post_id')->constrained()->restrictOnDelete();
             $table->string('content', 150)->nullable()->comment('本文');
             $table->string('image1')->nullable()->comment('添付画像1');
             $table->string('image2')->nullable()->comment('添付画像2');

--- a/public/js/deleteConfirm.js
+++ b/public/js/deleteConfirm.js
@@ -1,0 +1,17 @@
+//ポストの削除確認
+function deletePost(id) {
+    'use strict'
+    
+    if (confirm('復元できません。本当に削除しますか？')) {
+        document.getElementById(`deletePost${id}`).submit();
+    }
+}
+
+//コメントの削除確認
+function deleteComment(id) {
+    'use strict'
+    
+    if (confirm('復元できませんjjj。本当に削除しますか？')) {
+        document.getElementById(`deleteComment${id}`).submit();
+    }
+}

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -16,39 +16,56 @@
                 <div class='posts'>
                     @foreach ($posts as $post)
                         <div class="border border-black rounded mt-10 p-4">
-                            <a href="posts/{{ $post->id }}" class='post w-4/5 mx-auto'>
-                                <div class="w-10 h-10 border-1 border-black rounded-full">
-                                    @if($post->user->profile_image)
-                                        <img src="{{ $post->user->profile_image }}" alt="プロフィール画像"/>
-                                    @else
-                                        <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
-                                    @endif
-                                </div>
-                                <h2 class='user-name'>{{ $post->user->name }}</h2>
+                            <div class="flex justify-between mx-auto">
                                 <div>
-                                    @foreach ($post->user->usertags as $usertag)
-                                        <span class="mr-4">{{ $usertag->name }}</span>
-                                    @endforeach
-                                </div>
-                                <p class='body'>{{ $post->content }}</p>
-                                    @if($post->image1)
-                                        <div class="flex overflow-x-scroll">
-                                            <img class="w-2/5" src="{{ $post->image1 }}" alt="画像が読み込めません。"/>
-                                            @if($post->image2)
-                                                <img class="w-2/5 ml-4" src="{{ $post->image2 }}" alt="画像が読み込めません。"/>
-                                                @if($post->image3)
-                                                    <img class="w-2/5 ml-4" src="{{ $post->image3 }}" alt="画像が読み込めません。"/>
-                                                    @if($post->image4)
-                                                        <img class="w-2/5 ml-4" src="{{ $post->image4 }}" alt="画像が読み込めません。"/>
-                                                    @endif
-                                                @endif
+                                    <div class="flex">
+                                        <div class="w-10 h-10 border-1 border-black rounded-full">
+                                            @if($post->user->profile_image)
+                                                <img src="{{ $post->user->profile_image }}" alt="プロフィール画像"/>
+                                            @else
+                                                <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
                                             @endif
                                         </div>
+                                        <h2 class='user-name'>{{ $post->user->name }}</h2>
+                                    </div>
+                                    <div>
+                                        @foreach ($post->user->usertags as $usertag)
+                                            <span class="mr-4">{{ $usertag->name }}</span>
+                                        @endforeach
+                                    </div>
+                                </div>
+                                @if($post->user_id == Auth::id())
+                                    <div>
+                                        <form action="/posts/{{ $post->id }}" id="deletePost{{ $post->id }}" method="post">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="button" onClick="deletePost({{ $post->id }})" class="z-10 p-2 border border-black">削除</button>
+                                        </form>
+                                    </div>
+                                @endif
+                            </div>
+                            <p class='body'>{{ $post->content }}</p>
+                            @if($post->image1)
+                                <div class="flex overflow-x-scroll">
+                                    <img class="w-2/5" src="{{ $post->image1 }}" alt="画像が読み込めません。"/>
+                                    @if($post->image2)
+                                        <img class="w-2/5 ml-4" src="{{ $post->image2 }}" alt="画像が読み込めません。"/>
+                                        @if($post->image3)
+                                            <img class="w-2/5 ml-4" src="{{ $post->image3 }}" alt="画像が読み込めません。"/>
+                                            @if($post->image4)
+                                                <img class="w-2/5 ml-4" src="{{ $post->image4 }}" alt="画像が読み込めません。"/>
+                                            @endif
+                                        @endif
                                     @endif
-                                <p class='category'>カテゴリー名: {{ $post->category->name }}</p>
-                                <p class='comments'>コメント数: {{ $post->comments->count() }}</p>
-                                <p class='likes'>いいね数: {{ $post->likes->count() }}</p>
-                            </a>
+                                </div>
+                            @endif
+                            <p class='category'>カテゴリー名: {{ $post->category->name }}</p>
+                            <p class='comments'>コメント数: {{ $post->comments->count() }}</p>
+                            <p class='likes'>いいね数: {{ $post->likes->count() }}</p>
+                            <small>投稿日: {{ $post->created_at }}</small>
+                            <div class="text-center mx-auto my-2">
+                                <a href="/posts/{{ $post->id }}" class="inline-block w-10/12 py-2 border border-black">詳細ページへ</a>
+                            </div>
                         </div>
                     @endforeach
                 </div>
@@ -67,6 +84,7 @@
                     </div>
                 </form>
             </div>
+            <script src="{{ asset('js/deleteConfirm.js') }}"></script>
         </body>
     </x-app-layout>
 </html>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -17,18 +17,33 @@
                     
                     
                     <div class='post mt-4 mx-auto border border-black rounded p-4'>
-                        <div class="w-10 h-10 border-1 border-black rounded-full">
-                            @if($post->user->profile_image)
-                                <img src="{{ $post->user->profile_image }}" alt="プロフィール画像"/>
-                            @else
-                                <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
+                        <div class="flex justify-between">
+                            <div>
+                                <div class="flex">
+                                    <div class="w-10 h-10 border-1 border-black rounded-full">
+                                        @if($post->user->profile_image)
+                                            <img src="{{ $post->user->profile_image }}" alt="プロフィール画像"/>
+                                        @else
+                                            <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
+                                        @endif
+                                    </div>
+                                    <h2 class='user-name'>{{ $post->user->name }}</h2>
+                                </div>
+                                <div>
+                                    @foreach ($post->user->usertags as $usertag)
+                                        <span class="mr-4">{{ $usertag->name }}</span>
+                                    @endforeach
+                                </div>
+                            </div>
+                            @if($post->user_id == Auth::id())
+                                <div>
+                                    <form action="/posts/{{ $post->id }}" id="deletePost{{ $post->id }}" method="post">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="button" onClick="deletePost({{ $post->id }})" class="z-10 p-2 border border-black">削除</button>
+                                    </form>
+                                </div>
                             @endif
-                        </div>
-                        <h2 class='user-name'>{{ $post->user->name }}</h2>
-                        <div>
-                            @foreach ($post->user->usertags as $usertag)
-                                <span class="mr-4">{{ $usertag->name }}</span>
-                            @endforeach
                         </div>
                         <p class='body'>{{ $post->content }}</p>
                         @if($post->image1)
@@ -48,6 +63,7 @@
                         <p class='category'>カテゴリー名: {{ $post->category->name }}</p>
                         <p class='comments'>コメント数: {{ $post->comments->count() }}</p>
                         <p class='likes'>いいね数: {{ $post->likes->count() }}</p>
+                        <small>投稿日: {{ $post->created_at }}</small>
                     </div>
                     <div class='mt-10 mx-auto border-t-2 border-black'>
                         <button class="p-4 mt-4 border-2 border-black rounded">
@@ -55,18 +71,33 @@
                         </button>
                         @foreach ($post->comments as $comment)
                             <div class='post mt-4 border-t border-black p-4'>
-                                <div class="w-10 h-10 border-1 border-black rounded-full">
-                                    @if($comment->user->profile_image)
-                                        <img src="{{ $comment->user->profile_image }}" alt="プロフィール画像"/>
-                                    @else
-                                        <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
+                                <div class="flex justify-between">
+                                    <div>
+                                        <div class="flex">
+                                            <div class="w-10 h-10 border-1 border-black rounded-full">
+                                                @if($comment->user->profile_image)
+                                                    <img src="{{ $comment->user->profile_image }}" alt="プロフィール画像"/>
+                                                @else
+                                                    <img src="https://res.cloudinary.com/drs9gzes2/image/upload/v1695132757/kkrn_icon_user_14_evxlot.png" alt="プロフィール画像"/>
+                                                @endif
+                                            </div>
+                                            <h2 class='user-name'>{{ $comment->user->name }}</h2>
+                                        </div>
+                                        <div>
+                                            @foreach ($comment->user->usertags as $usertag)
+                                                <span class="mr-4">{{ $usertag->name }}</span>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                    @if($comment->user_id == Auth::id())
+                                        <div>
+                                            <form action="/comments/{{ $comment->id }}" id="deleteComment{{ $comment->id }}" method="post">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="button" onClick="deleteComment({{ $comment->id }})" class="z-10 p-2 border border-black">削除</button>
+                                            </form>
+                                        </div>
                                     @endif
-                                </div>
-                                <h2 class='user-name'>{{ $comment->user->name }}</h2>
-                                <div>
-                                    @foreach ($comment->user->usertags as $usertag)
-                                        <span class="mr-4">{{ $usertag->name }}</span>
-                                    @endforeach
                                 </div>
                                 <p class='body'>{{ $comment->content }}</p>
                                 @if($comment->image1)
@@ -83,6 +114,7 @@
                                         @endif
                                     </div>
                                 @endif
+                                <small>投稿日: {{ $comment->created_at }}</small>
                             </div>
                         @endforeach
                     </div>
@@ -90,7 +122,7 @@
             </div>
             
             <div class="mt-10">
-                <form class="flex flex-col text-center w-3/5 mx-auto border border-black rounded p-4" action="/posts/comment" method="POST" enctype="multipart/form-data">
+                <form class="flex flex-col text-center w-3/5 mx-auto border border-black rounded p-4" action="/comments" method="POST" enctype="multipart/form-data">
                     @csrf
                     @if ($errors->any())
                         <div class="alert alert-danger mb-4">
@@ -111,6 +143,7 @@
                 </form>
             </div>
             <script src="{{ asset('js/formCheck.js') }}"></script>
+            <script src="{{ asset('js/deleteConfirm.js') }}"></script>
         </body>
     </x-app-layout>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,10 +33,12 @@ Route::controller(Postcontroller::class)->middleware('auth')->group(function() {
     Route::post('/posts', 'store')->name('store');
     Route::get('/posts/create', 'create')->name('create');
     Route::get('/posts/{post}', 'show')->name('show');
+    Route::delete('/posts/{post}', 'delete')->name('deletePost');
 });
 
 Route::controller(Commentcontroller::class)->middleware('auth')->group(function() {
-    Route::post('/posts/comment', 'comment')->name('comment');
+    Route::post('/comments', 'comment')->name('comment');
+    Route::delete('/comments/{comment}', 'delete')->name('deleteComment');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
投稿とコメントの削除機能と削除時のDBのエラー処理の実装をしました。
自分の投稿とコメントにのみ削除ボタンを設置し、すべての投稿とコメントに投稿日を表示しました。
トップページの投稿には「詳細ページへ」のボタンを設置しました。